### PR TITLE
Add FusedCovCacheMode for GICP and VGICP

### DIFF
--- a/include/gtsam_points/factors/impl/integrated_gicp_factor_impl.hpp
+++ b/include/gtsam_points/factors/impl/integrated_gicp_factor_impl.hpp
@@ -7,6 +7,7 @@
 #include <gtsam/linear/HessianFactor.h>
 #include <gtsam_points/config.hpp>
 #include <gtsam_points/ann/kdtree2.hpp>
+#include <gtsam_points/util/compact.hpp>
 #include <gtsam_points/util/parallelism.hpp>
 #include <gtsam_points/types/frame_traits.hpp>
 #include <gtsam_points/factors/impl/scan_matching_reduction.hpp>
@@ -27,6 +28,7 @@ IntegratedGICPFactor_<TargetFrame, SourceFrame>::IntegratedGICPFactor_(
 : gtsam_points::IntegratedMatchingCostFactor(target_key, source_key),
   num_threads(1),
   max_correspondence_distance_sq(1.0),
+  mahalanobis_cache_mode(FusedCovCacheMode::FULL),
   correspondence_update_tolerance_rot(0.0),
   correspondence_update_tolerance_trans(0.0),
   target(target),
@@ -67,6 +69,7 @@ IntegratedGICPFactor_<TargetFrame, SourceFrame>::IntegratedGICPFactor_(
 : gtsam_points::IntegratedMatchingCostFactor(fixed_target_pose, source_key),
   num_threads(1),
   max_correspondence_distance_sq(1.0),
+  mahalanobis_cache_mode(FusedCovCacheMode::FULL),
   correspondence_update_tolerance_rot(0.0),
   correspondence_update_tolerance_trans(0.0),
   target(target),
@@ -102,6 +105,8 @@ IntegratedGICPFactor_<TargetFrame, SourceFrame>::~IntegratedGICPFactor_() {}
 
 template <typename TargetFrame, typename SourceFrame>
 void IntegratedGICPFactor_<TargetFrame, SourceFrame>::update_correspondences(const Eigen::Isometry3d& delta) const {
+  linearization_point = delta;
+
   bool do_update = true;
   if (correspondences.size() == frame::size(*source) && (correspondence_update_tolerance_trans > 0.0 || correspondence_update_tolerance_rot > 0.0)) {
     Eigen::Isometry3d diff = delta.inverse() * last_correspondence_point;
@@ -117,7 +122,17 @@ void IntegratedGICPFactor_<TargetFrame, SourceFrame>::update_correspondences(con
   }
 
   correspondences.resize(frame::size(*source));
-  mahalanobis.resize(frame::size(*source));
+
+  switch (mahalanobis_cache_mode) {
+    case FusedCovCacheMode::FULL:
+      mahalanobis_full.resize(frame::size(*source));
+      break;
+    case FusedCovCacheMode::COMPACT:
+      mahalanobis_compact.resize(frame::size(*source));
+      break;
+    case FusedCovCacheMode::NONE:
+      break;
+  }
 
   const auto perpoint_task = [&](int i) {
     if (do_update) {
@@ -129,15 +144,29 @@ void IntegratedGICPFactor_<TargetFrame, SourceFrame>::update_correspondences(con
       correspondences[i] = (num_found && k_sq_dist < max_correspondence_distance_sq) ? k_index : -1;
     }
 
-    if (correspondences[i] < 0) {
-      mahalanobis[i].setZero();
-    } else {
-      const auto& target_cov = frame::cov(*target, correspondences[i]);
-      Eigen::Matrix4d RCR = (target_cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
-
-      RCR(3, 3) = 1.0;
-      mahalanobis[i] = RCR.inverse();
-      mahalanobis[i](3, 3) = 0.0;
+    switch (mahalanobis_cache_mode) {
+      case FusedCovCacheMode::FULL:
+        if (correspondences[i] < 0) {
+          mahalanobis_full[i].setZero();
+        } else {
+          const auto& target_cov = frame::cov(*target, correspondences[i]);
+          const Eigen::Matrix4d RCR = (target_cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
+          mahalanobis_full[i].setZero();
+          mahalanobis_full[i].topLeftCorner<3, 3>() = RCR.topLeftCorner<3, 3>().inverse();
+        }
+        break;
+      case FusedCovCacheMode::COMPACT:
+        if (correspondences[i] < 0) {
+          mahalanobis_compact[i].setZero();
+        } else {
+          const auto& target_cov = frame::cov(*target, correspondences[i]);
+          const Eigen::Matrix4d RCR = (target_cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
+          const Eigen::Matrix3d maha = RCR.topLeftCorner<3, 3>().inverse();
+          mahalanobis_compact[i] = compact_cov(maha);
+        }
+        break;
+      case FusedCovCacheMode::NONE:
+        break;
     }
   };
 
@@ -193,7 +222,23 @@ double IntegratedGICPFactor_<TargetFrame, SourceFrame>::evaluate(
     const Eigen::Vector4d transed_mean_A = delta * mean_A;
     const Eigen::Vector4d residual = mean_B - transed_mean_A;
 
-    const double error = 0.5 * residual.transpose() * mahalanobis[i] * residual;
+    Eigen::Matrix4d mahalanobis;
+    switch (mahalanobis_cache_mode) {
+      case FusedCovCacheMode::FULL:
+        mahalanobis = mahalanobis_full[i];
+        break;
+      case FusedCovCacheMode::COMPACT:
+        mahalanobis = uncompact_cov(mahalanobis_compact[i]);
+        break;
+      case FusedCovCacheMode::NONE: {
+        const auto& delta_l = linearization_point;  // Delta at the linearization point
+        const Eigen::Matrix4d RCR = (cov_B + delta_l.matrix() * cov_A * delta_l.matrix().transpose());
+        mahalanobis.setZero();
+        mahalanobis.topLeftCorner<3, 3>() = RCR.topLeftCorner<3, 3>().inverse();
+      } break;
+    }
+
+    const double error = 0.5 * residual.transpose() * mahalanobis * residual;
     if (H_target == nullptr) {
       return error;
     }
@@ -206,8 +251,8 @@ double IntegratedGICPFactor_<TargetFrame, SourceFrame>::evaluate(
     J_source.block<3, 3>(0, 0) = delta.linear() * gtsam::SO3::Hat(mean_A.template head<3>());
     J_source.block<3, 3>(0, 3) = -delta.linear();
 
-    Eigen::Matrix<double, 6, 4> J_target_mahalanobis = J_target.transpose() * mahalanobis[i];
-    Eigen::Matrix<double, 6, 4> J_source_mahalanobis = J_source.transpose() * mahalanobis[i];
+    Eigen::Matrix<double, 6, 4> J_target_mahalanobis = J_target.transpose() * mahalanobis;
+    Eigen::Matrix<double, 6, 4> J_source_mahalanobis = J_source.transpose() * mahalanobis;
 
     *H_target += J_target_mahalanobis * J_target;
     *H_source += J_source_mahalanobis * J_source;

--- a/include/gtsam_points/factors/impl/integrated_vgicp_factor_impl.hpp
+++ b/include/gtsam_points/factors/impl/integrated_vgicp_factor_impl.hpp
@@ -8,6 +8,7 @@
 #include <gtsam_points/config.hpp>
 #include <gtsam_points/types/gaussian_voxelmap_cpu.hpp>
 #include <gtsam_points/util/parallelism.hpp>
+#include <gtsam_points/util/compact.hpp>
 #include <gtsam_points/factors/impl/scan_matching_reduction.hpp>
 
 #ifdef GTSAM_POINTS_USE_TBB
@@ -24,6 +25,7 @@ IntegratedVGICPFactor_<SourceFrame>::IntegratedVGICPFactor_(
   const std::shared_ptr<const SourceFrame>& source)
 : gtsam_points::IntegratedMatchingCostFactor(target_key, source_key),
   num_threads(1),
+  mahalanobis_cache_mode(FusedCovCacheMode::FULL),
   target_voxels(std::dynamic_pointer_cast<const GaussianVoxelMapCPU>(target_voxels)),
   source(source) {
   //
@@ -51,6 +53,7 @@ IntegratedVGICPFactor_<SourceFrame>::IntegratedVGICPFactor_(
   const std::shared_ptr<const SourceFrame>& source)
 : gtsam_points::IntegratedMatchingCostFactor(fixed_target_pose, source_key),
   num_threads(1),
+  mahalanobis_cache_mode(FusedCovCacheMode::FULL),
   target_voxels(std::dynamic_pointer_cast<const GaussianVoxelMapCPU>(target_voxels)),
   source(source) {
   //
@@ -75,8 +78,19 @@ IntegratedVGICPFactor_<SourceFrame>::~IntegratedVGICPFactor_() {}
 
 template <typename SourceFrame>
 void IntegratedVGICPFactor_<SourceFrame>::update_correspondences(const Eigen::Isometry3d& delta) const {
+  linearization_point = delta;
   correspondences.resize(frame::size(*source));
-  mahalanobis.resize(frame::size(*source));
+
+  switch (mahalanobis_cache_mode) {
+    case FusedCovCacheMode::FULL:
+      mahalanobis_full.resize(frame::size(*source));
+      break;
+    case FusedCovCacheMode::COMPACT:
+      mahalanobis_compact.resize(frame::size(*source));
+      break;
+    case FusedCovCacheMode::NONE:
+      break;
+  }
 
   const auto perpoint_task = [&](int i) {
     Eigen::Vector4d pt = delta * frame::point(*source, i);
@@ -85,16 +99,37 @@ void IntegratedVGICPFactor_<SourceFrame>::update_correspondences(const Eigen::Is
 
     if (voxel_id < 0) {
       correspondences[i] = nullptr;
-      mahalanobis[i].setIdentity();
+
+      switch (mahalanobis_cache_mode) {
+        case FusedCovCacheMode::FULL:
+          mahalanobis_full[i].setZero();
+          break;
+        case FusedCovCacheMode::COMPACT:
+          mahalanobis_compact[i].setZero();
+          break;
+        case FusedCovCacheMode::NONE:
+          break;
+      }
     } else {
       const auto voxel = &target_voxels->lookup_voxel(voxel_id);
-
       correspondences[i] = voxel;
 
-      Eigen::Matrix4d RCR = (voxel->cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
-      RCR(3, 3) = 1.0;
-      mahalanobis[i] = RCR.inverse();
-      mahalanobis[i](3, 3) = 0.0;
+      switch (mahalanobis_cache_mode) {
+        case FusedCovCacheMode::FULL: {
+          const Eigen::Matrix4d RCR = (voxel->cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
+          mahalanobis_full[i].setZero();
+          mahalanobis_full[i].topLeftCorner<3, 3>() = RCR.topLeftCorner<3, 3>().inverse();
+          break;
+        }
+        case FusedCovCacheMode::COMPACT: {
+          const Eigen::Matrix4d RCR = (voxel->cov + delta.matrix() * frame::cov(*source, i) * delta.matrix().transpose());
+          const Eigen::Matrix3d maha = RCR.topLeftCorner<3, 3>().inverse();
+          mahalanobis_compact[i] = compact_cov(maha);
+          break;
+        }
+        case FusedCovCacheMode::NONE:
+          break;
+      }
     }
   };
 
@@ -153,7 +188,23 @@ double IntegratedVGICPFactor_<SourceFrame>::evaluate(
     Eigen::Vector4d transed_mean_A = delta * mean_A;
     Eigen::Vector4d residual = mean_B - transed_mean_A;
 
-    const double error = 0.5 * residual.transpose() * mahalanobis[i] * residual;
+    Eigen::Matrix4d mahalanobis;
+    switch (mahalanobis_cache_mode) {
+      case FusedCovCacheMode::FULL:
+        mahalanobis = mahalanobis_full[i];
+        break;
+      case FusedCovCacheMode::COMPACT:
+        mahalanobis = uncompact_cov(mahalanobis_compact[i]);
+        break;
+      case FusedCovCacheMode::NONE: {
+        const auto& delta_l = linearization_point;  // Delta at the linearization point
+        const Eigen::Matrix4d RCR = (cov_B + delta_l.matrix() * cov_A * delta_l.matrix().transpose());
+        mahalanobis.setZero();
+        mahalanobis.topLeftCorner<3, 3>() = RCR.topLeftCorner<3, 3>().inverse();
+      } break;
+    }
+
+    const double error = 0.5 * residual.transpose() * mahalanobis * residual;
 
     if (!H_target) {
       return error;
@@ -167,8 +218,8 @@ double IntegratedVGICPFactor_<SourceFrame>::evaluate(
     J_source.block<3, 3>(0, 0) = delta.linear() * gtsam::SO3::Hat(mean_A.template head<3>());
     J_source.block<3, 3>(0, 3) = -delta.linear();
 
-    Eigen::Matrix<double, 6, 4> J_target_mahalanobis = J_target.transpose() * mahalanobis[i];
-    Eigen::Matrix<double, 6, 4> J_source_mahalanobis = J_source.transpose() * mahalanobis[i];
+    Eigen::Matrix<double, 6, 4> J_target_mahalanobis = J_target.transpose() * mahalanobis;
+    Eigen::Matrix<double, 6, 4> J_source_mahalanobis = J_source.transpose() * mahalanobis;
 
     *H_target += J_target_mahalanobis * J_target;
     *H_source += J_source_mahalanobis * J_source;

--- a/include/gtsam_points/factors/integrated_vgicp_factor.hpp
+++ b/include/gtsam_points/factors/integrated_vgicp_factor.hpp
@@ -9,6 +9,7 @@
 #include <gtsam_points/types/point_cloud.hpp>
 #include <gtsam_points/types/gaussian_voxelmap_cpu.hpp>
 #include <gtsam_points/factors/integrated_matching_cost_factor.hpp>
+#include <gtsam_points/factors/integrated_gicp_factor.hpp>
 
 namespace gtsam_points {
 
@@ -58,6 +59,9 @@ public:
   ///       and setting n>1 can rather affect the processing speed.
   void set_num_threads(int n) { num_threads = n; }
 
+  /// @brief Set the cache mode for fused covariance matrices (i.e., mahalanobis).
+  void set_fused_cov_cache_mode(FusedCovCacheMode mode) { mahalanobis_cache_mode = mode; }
+
   /// @brief Compute the fraction of inlier points that have correspondences with a distance smaller than the trimming threshold.
   double inlier_fraction() const {
     const int outliers = std::count(correspondences.begin(), correspondences.end(), nullptr);
@@ -78,10 +82,13 @@ private:
 
 private:
   int num_threads;
+  FusedCovCacheMode mahalanobis_cache_mode;
 
   // I'm unhappy to have mutable members...
+  mutable Eigen::Isometry3d linearization_point;
   mutable std::vector<const GaussianVoxel*> correspondences;
-  mutable std::vector<Eigen::Matrix4d> mahalanobis;
+  mutable std::vector<Eigen::Matrix4d> mahalanobis_full;
+  mutable std::vector<Eigen::Matrix<float, 6, 1>> mahalanobis_compact;
 
   std::shared_ptr<const GaussianVoxelMapCPU> target_voxels;
   std::shared_ptr<const SourceFrame> source;

--- a/include/gtsam_points/util/compact.hpp
+++ b/include/gtsam_points/util/compact.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021  Kenji Koide (k.koide@aist.go.jp)
+#pragma once
+
+#include <Eigen/Core>
+
+namespace gtsam_points {
+
+template <int D>
+inline Eigen::Matrix<float, 6, 1> compact_cov(const Eigen::Matrix<double, D, D>& cov) {
+  Eigen::Matrix<float, 6, 1> compact;
+  compact << cov(0, 0), cov(1, 0), cov(1, 1), cov(2, 0), cov(2, 1), cov(2, 2);
+  return compact;
+}
+
+inline Eigen::Matrix4d uncompact_cov(const Eigen::Matrix<float, 6, 1>& compact) {
+  Eigen::Matrix4d cov = Eigen::Matrix4d::Zero();
+  cov(0, 0) = compact(0);
+  cov(1, 0) = cov(0, 1) = compact(1);
+  cov(1, 1) = compact(2);
+  cov(2, 0) = cov(0, 2) = compact(3);
+  cov(2, 1) = cov(1, 2) = compact(4);
+  cov(2, 2) = compact(5);
+  return cov;
+}
+
+}  // namespace gtsam_points

--- a/src/test/test_compact_mahalanobis.cpp
+++ b/src/test/test_compact_mahalanobis.cpp
@@ -1,0 +1,160 @@
+#include <vector>
+#include <iostream>
+#include <Eigen/Core>
+
+#include <gtest/gtest.h>
+#include <gtsam/base/make_shared.h>
+#include <gtsam_points/util/compact.hpp>
+#include <gtsam_points/util/read_points.hpp>
+#include <gtsam_points/util/covariance_estimation.hpp>
+#include <gtsam_points/ann/kdtree.hpp>
+#include <gtsam_points/types/point_cloud_cpu.hpp>
+#include <gtsam_points/types/gaussian_voxelmap_cpu.hpp>
+#include <gtsam_points/factors/integrated_gicp_factor.hpp>
+#include <gtsam_points/factors/integrated_vgicp_factor.hpp>
+
+TEST(CompactTest, CompactUncompact) {
+  for (int i = 0; i < 10; i++) {
+    const Eigen::Matrix3d rand3 = Eigen::Matrix3d::Random();
+    Eigen::Matrix4d cov = Eigen::Matrix4d::Zero();
+    cov.topLeftCorner<3, 3>() = rand3 * rand3.transpose();
+
+    const Eigen::Matrix<float, 6, 1> compact = gtsam_points::compact_cov(cov);
+    const Eigen::Matrix4d cov2 = gtsam_points::uncompact_cov(compact);
+
+    EXPECT_NEAR((cov - cov2).norm(), 0.0, 1e-6);
+  }
+}
+
+TEST(CompactTest, UnusedElements) {
+  for (int i = 0; i < 10; i++) {
+    Eigen::Matrix4d cov = Eigen::Matrix4d::Random();
+    cov = cov * cov.transpose();
+
+    const Eigen::Matrix<float, 6, 1> compact = gtsam_points::compact_cov(cov);
+    const Eigen::Matrix4d cov2 = gtsam_points::uncompact_cov(compact);
+
+    EXPECT_NEAR(cov2.bottomRows<1>().norm(), 0.0, 1e-6);
+    EXPECT_NEAR(cov2.rightCols<1>().norm(), 0.0, 1e-6);
+  }
+}
+
+class CompactMahalanobisTestBase : public testing::Test {
+public:
+  virtual void SetUp() override {
+    const std::string data_path = "./data/kitti_00";
+
+    const auto load_points = [](const std::string& filename) -> gtsam_points::PointCloudCPU::Ptr {
+      const auto raw = gtsam_points::read_points(filename);
+      if (raw.empty()) {
+        std::cerr << "Failed to read " << filename << std::endl;
+        return nullptr;
+      }
+
+      auto points = std::make_shared<gtsam_points::PointCloudCPU>(raw);
+      points = gtsam_points::voxelgrid_sampling(points, 0.25);
+      points->add_covs(gtsam_points::estimate_covariances(points->points, points->size()));
+      return points;
+    };
+
+    target = load_points(data_path + "/000000.bin");
+    source = load_points(data_path + "/000001.bin");
+    if (target) {
+      target_tree = std::make_shared<gtsam_points::KdTree>(target->points, target->size());
+
+      auto voxels = std::make_shared<gtsam_points::GaussianVoxelMapCPU>(1.0);
+      voxels->insert(*target);
+      target_voxels = voxels;
+    }
+  }
+
+  gtsam_points::PointCloudCPU::ConstPtr target;
+  gtsam_points::PointCloudCPU::ConstPtr source;
+  gtsam_points::KdTree::ConstPtr target_tree;
+  gtsam_points::GaussianVoxelMap::ConstPtr target_voxels;
+};
+
+TEST_F(CompactMahalanobisTestBase, LoadCheck) {
+  ASSERT_NE(target, nullptr);
+  ASSERT_NE(source, nullptr);
+  ASSERT_NE(target_tree, nullptr);
+}
+
+class CompactMahalanobisTest : public CompactMahalanobisTestBase, public testing::WithParamInterface<std::string> {
+public:
+  std::tuple<gtsam::NonlinearFactor::shared_ptr, gtsam::NonlinearFactor::shared_ptr, gtsam::NonlinearFactor::shared_ptr> create_factor() {
+    const auto method = GetParam();
+
+    if (method == "GICP") {
+      auto factor_full = gtsam::make_shared<gtsam_points::IntegratedGICPFactor>(0, 1, target, source, target_tree);
+      factor_full->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::FULL);
+
+      auto factor_compact = gtsam::make_shared<gtsam_points::IntegratedGICPFactor>(0, 1, target, source, target_tree);
+      factor_compact->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::COMPACT);
+
+      auto factor_none = gtsam::make_shared<gtsam_points::IntegratedGICPFactor>(0, 1, target, source, target_tree);
+      factor_none->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::NONE);
+
+      return {factor_full, factor_compact, factor_none};
+    } else if (method == "VGICP") {
+      auto factor_full = gtsam::make_shared<gtsam_points::IntegratedVGICPFactor>(0, 1, target_voxels, source);
+      factor_full->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::FULL);
+
+      auto factor_compact = gtsam::make_shared<gtsam_points::IntegratedVGICPFactor>(0, 1, target_voxels, source);
+      factor_compact->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::COMPACT);
+
+      auto factor_none = gtsam::make_shared<gtsam_points::IntegratedVGICPFactor>(0, 1, target_voxels, source);
+      factor_none->set_fused_cov_cache_mode(gtsam_points::FusedCovCacheMode::NONE);
+
+      return {factor_full, factor_compact, factor_none};
+    } else {
+      std::cerr << "Unknown method: " << method << std::endl;
+    }
+
+    return std::tuple<gtsam::NonlinearFactor::shared_ptr, gtsam::NonlinearFactor::shared_ptr, gtsam::NonlinearFactor::shared_ptr>();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(gtsam_points, CompactMahalanobisTest, testing::Values("GICP", "VGICP"), [](const auto& info) { return info.param; });
+
+TEST_P(CompactMahalanobisTest, FactorTest) {
+  const auto factors = create_factor();
+  const auto factor_full = std::get<0>(factors);
+  const auto factor_compact = std::get<1>(factors);
+  const auto factor_none = std::get<2>(factors);
+
+  std::mt19937 mt;
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+
+  for (int i = 0; i < 3; i++) {
+    gtsam::Vector6 noise1, noise2;
+    std::generate(noise1.begin(), noise1.end(), [&] { return dist(mt) * 0.5; });
+    std::generate(noise2.begin(), noise2.end(), [&] { return dist(mt) * 0.5; });
+
+    gtsam::Values values;
+    values.insert(0, gtsam::Pose3::Expmap(noise1));
+    values.insert(1, gtsam::Pose3::Expmap(noise2));
+
+    const auto linear_full = factor_full->linearize(values);
+    const auto linear_compact = factor_compact->linearize(values);
+    const auto linear_none = factor_none->linearize(values);
+
+    const auto info_full = linear_full->augmentedInformation();
+    const auto info_compact = linear_compact->augmentedInformation();
+    const auto info_none = linear_none->augmentedInformation();
+
+    EXPECT_NEAR((info_full - info_compact).cwiseAbs2().maxCoeff(), 0.0, 1e-3) << "Large augmented info error (full vs. compact)";
+    EXPECT_NEAR((info_full - info_none).cwiseAbs2().maxCoeff(), 0.0, 1e-3) << "Large augmented info error (full vs. none)";
+
+    gtsam::Vector6 noise3;
+    std::generate(noise3.begin(), noise3.end(), [&] { return dist(mt) * 0.1; });
+    values.insert_or_assign(0, gtsam::Pose3::Expmap(noise2) * gtsam::Pose3::Expmap(noise3));
+
+    const double error_full = factor_full->error(values);
+    const double error_compact = factor_compact->error(values);
+    const double error_none = factor_none->error(values);
+
+    EXPECT_NEAR(error_full, error_compact, 1e-3) << "Large error (full vs. compact)";
+    EXPECT_NEAR(error_full, error_none, 1e-3) << "Large error (full vs. none)";
+  }
+}

--- a/src/test/test_compact_mahalanobis.cpp
+++ b/src/test/test_compact_mahalanobis.cpp
@@ -128,8 +128,8 @@ TEST_P(CompactMahalanobisTest, FactorTest) {
 
   for (int i = 0; i < 3; i++) {
     gtsam::Vector6 noise1, noise2;
-    std::generate(noise1.begin(), noise1.end(), [&] { return dist(mt) * 0.5; });
-    std::generate(noise2.begin(), noise2.end(), [&] { return dist(mt) * 0.5; });
+    std::generate(noise1.data(), noise1.data() + noise1.size(), [&] { return dist(mt) * 0.5; });
+    std::generate(noise2.data(), noise2.data() + noise2.size(), [&] { return dist(mt) * 0.5; });
 
     gtsam::Values values;
     values.insert(0, gtsam::Pose3::Expmap(noise1));
@@ -147,7 +147,7 @@ TEST_P(CompactMahalanobisTest, FactorTest) {
     EXPECT_NEAR((info_full - info_none).cwiseAbs2().maxCoeff(), 0.0, 1e-3) << "Large augmented info error (full vs. none)";
 
     gtsam::Vector6 noise3;
-    std::generate(noise3.begin(), noise3.end(), [&] { return dist(mt) * 0.1; });
+    std::generate(noise3.data(), noise3.data() + noise3.size(), [&] { return dist(mt) * 0.1; });
     values.insert_or_assign(0, gtsam::Pose3::Expmap(noise2) * gtsam::Pose3::Expmap(noise3));
 
     const double error_full = factor_full->error(values);


### PR DESCRIPTION
Add an option to change the cache mode of fused covariance matrices (i.e., `mahalanobis`)
- `FusedCovCacheMode::FULL` : Stores cached cov as 4x4 double matrix (128 bit per point, fast)
- `FusedCovCacheMode::COMPACT` : Stores cached cov as 3x3 float upper-triangular matrix (24 bit per point, fast)
- `FusedCovCacheMode::NONE` : Do not cache fused covs (re-calculate them every linearization) (0 bit per point, slow)
