### PR TITLE
Integrate intensity data into GPU point cloud processing pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ find_package(Boost REQUIRED COMPONENTS graph filesystem)
 find_package(GTSAM 4.3 REQUIRED)
 find_package(GTSAM_UNSTABLE 4.3 REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(PCL 1.8 REQUIRED COMPONENTS common io)
+
+include_directories(SYSTEM ${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
 
 if(BUILD_WITH_TBB)
   find_package(TBB REQUIRED)

--- a/include/gtsam_points/types/gaussian_voxel_data.hpp
+++ b/include/gtsam_points/types/gaussian_voxel_data.hpp
@@ -15,11 +15,13 @@ public:
   GaussianVoxelData(const Eigen::Vector3i& coord, const GaussianVoxel& voxel) {
     const auto& mean = voxel.mean;
     const auto& cov = voxel.cov;
+    const auto& intensity = voxel.intensity;
 
     this->coord = coord;
     this->num_points = voxel.num_points;
     this->mean << mean[0], mean[1], mean[2];
     this->cov << cov(0, 0), cov(0, 1), cov(0, 2), cov(1, 1), cov(1, 2), cov(2, 2);
+    this->intensity = intensity;
   }
 
   std::shared_ptr<std::pair<VoxelInfo, GaussianVoxel>> uncompact() const {
@@ -39,6 +41,7 @@ public:
     voxel.cov(1, 2) = voxel.cov(2, 1) = cov[4];
     voxel.cov(2, 2) = cov[5];
 
+    voxel.intensity = intensity;
     return uncompacted;
   }
 
@@ -47,6 +50,7 @@ public:
   int num_points;
   Eigen::Vector3f mean;
   Eigen::Matrix<float, 6, 1> cov;
+  float intensity;
 };
 
 }

--- a/include/gtsam_points/types/gaussian_voxelmap_cpu.hpp
+++ b/include/gtsam_points/types/gaussian_voxelmap_cpu.hpp
@@ -18,7 +18,7 @@ public:
   struct Setting {};
 
   /// @brief Constructor.
-  GaussianVoxel() : finalized(false), num_points(0), mean(Eigen::Vector4d::Zero()), cov(Eigen::Matrix4d::Zero()) {}
+  GaussianVoxel() : finalized(false), num_points(0), mean(Eigen::Vector4d::Zero()), cov(Eigen::Matrix4d::Zero()), intensity(0.0f) {}
 
   /// @brief  Number of points in the voxel (Always 1 for GaussianVoxel).
   size_t size() const { return 1; }
@@ -48,6 +48,7 @@ public:
   size_t num_points;     ///< Number of input points
   Eigen::Vector4d mean;  ///< Mean
   Eigen::Matrix4d cov;   ///< Covariance
+  float intensity;       ///< Intensity
 };
 
 namespace frame {
@@ -59,12 +60,12 @@ struct traits<GaussianVoxel> {
   static bool has_points(const GaussianVoxel& frame) { return true; }
   static bool has_normals(const GaussianVoxel& frame) { return false; }
   static bool has_covs(const GaussianVoxel& frame) { return true; }
-  static bool has_intensities(const GaussianVoxel& frame) { return false; }
+  static bool has_intensities(const GaussianVoxel& frame) { return true; }
 
   static const Eigen::Vector4d& point(const GaussianVoxel& frame, size_t i) { return frame.mean; }
   static const Eigen::Vector4d normal(const GaussianVoxel& frame, size_t i) { return Eigen::Vector4d::Zero(); }
   static const Eigen::Matrix4d& cov(const GaussianVoxel& frame, size_t i) { return frame.cov; }
-  static double intensity(const GaussianVoxel& frame, size_t i) { return 0.0; }
+  static float intensity(const GaussianVoxel& frame, size_t i) { return frame.intensity; }
 };
 
 }  // namespace frame

--- a/include/gtsam_points/types/gaussian_voxelmap_gpu.hpp
+++ b/include/gtsam_points/types/gaussian_voxelmap_gpu.hpp
@@ -89,6 +89,7 @@ public:
 
   // voxel data
   int* num_points;               ///< Number of points in eac voxel
+  float* voxel_intensities;      ///< Voxel intentisities
   Eigen::Vector3f* voxel_means;  ///< Voxel means
   Eigen::Matrix3f* voxel_covs;   ///< Voxel covariances
 };
@@ -97,5 +98,5 @@ std::vector<VoxelBucket> download_buckets(const GaussianVoxelMapGPU& voxelmap, C
 std::vector<int> download_voxel_num_points(const GaussianVoxelMapGPU& voxelmap, CUstream_st* stream = nullptr);
 std::vector<Eigen::Vector3f> download_voxel_means(const GaussianVoxelMapGPU& voxelmap, CUstream_st* stream = nullptr);
 std::vector<Eigen::Matrix3f> download_voxel_covs(const GaussianVoxelMapGPU& voxelmap, CUstream_st* stream = nullptr);
-
+std::vector<float> download_voxel_intensities(const GaussianVoxelMapGPU& vm,  CUstream_st* stream= nullptr);
 }  // namespace gtsam_points

--- a/src/gtsam_points/types/gaussian_voxelmap_gpu.cu
+++ b/src/gtsam_points/types/gaussian_voxelmap_gpu.cu
@@ -93,19 +93,22 @@ struct accumulate_points_kernel {
     const VoxelBucket* buckets,
     int* num_points,
     Eigen::Vector3f* voxel_means,
-    Eigen::Matrix3f* voxel_covs)
+    Eigen::Matrix3f* voxel_covs,
+    float* voxel_intensities)
   : voxelmap_info_ptr(voxelmap_info_ptr),
     buckets_ptr(buckets),
     num_points_ptr(num_points),
     voxel_means_ptr(voxel_means),
-    voxel_covs_ptr(voxel_covs) {}
+    voxel_covs_ptr(voxel_covs),
+    voxel_intensities_ptr(voxel_intensities) {}
 
-  __device__ void operator()(const thrust::tuple<Eigen::Vector3f, Eigen::Matrix3f>& input) const {
+  __device__ void operator()(const thrust::tuple<Eigen::Vector3f, Eigen::Matrix3f, float>& input) const {
     const auto& info = *thrust::raw_pointer_cast(voxelmap_info_ptr);
 
     const auto& mean = thrust::get<0>(input);
     const auto& cov = thrust::get<1>(input);
-
+    const float& intensity = thrust::get<2>(input);
+    
     const Eigen::Vector3i coord = calc_voxel_coord(mean, info.voxel_resolution);
     uint64_t hash = vector3i_hash(coord);
 
@@ -121,7 +124,7 @@ struct accumulate_points_kernel {
         int& num_points = thrust::raw_pointer_cast(num_points_ptr)[bucket.second];
         Eigen::Vector3f& voxel_mean = thrust::raw_pointer_cast(voxel_means_ptr)[bucket.second];
         Eigen::Matrix3f& voxel_cov = thrust::raw_pointer_cast(voxel_covs_ptr)[bucket.second];
-
+        float& voxel_intensity = thrust::raw_pointer_cast(voxel_intensities_ptr)[bucket.second];
         atomicAdd(&num_points, 1);
         for (int j = 0; j < 3; j++) {
           atomicAdd(voxel_mean.data() + j, mean[j]);
@@ -130,6 +133,9 @@ struct accumulate_points_kernel {
         for (int j = 0; j < 9; j++) {
           atomicAdd(voxel_cov.data() + j, cov.data()[j]);
         }
+        unsigned int *as_uint = reinterpret_cast<unsigned int*>(&voxel_intensity);
+        atomicMax(as_uint, __float_as_uint(intensity));                 // Max intensity value
+        //atomicAdd(thrust::raw_pointer_cast(voxel_intensities_ptr) + bucket.second, intensity); // Add intensity value for average intensity
       }
     }
   }
@@ -140,26 +146,31 @@ struct accumulate_points_kernel {
   thrust::device_ptr<int> num_points_ptr;
   thrust::device_ptr<Eigen::Vector3f> voxel_means_ptr;
   thrust::device_ptr<Eigen::Matrix3f> voxel_covs_ptr;
+  thrust::device_ptr<float> voxel_intensities_ptr;
 };
 
 struct finalize_voxels_kernel {
-  finalize_voxels_kernel(int* num_points, Eigen::Vector3f* voxel_means, Eigen::Matrix3f* voxel_covs)
+  finalize_voxels_kernel(int* num_points, Eigen::Vector3f* voxel_means, Eigen::Matrix3f* voxel_covs, float* voxel_intensities)
   : num_points_ptr(num_points),
     voxel_means_ptr(voxel_means),
-    voxel_covs_ptr(voxel_covs) {}
+    voxel_covs_ptr(voxel_covs),
+    voxel_intensities_ptr(voxel_intensities) {}
 
   __host__ __device__ void operator()(int i) const {
     int num_points = thrust::raw_pointer_cast(num_points_ptr)[i];
     auto& voxel_mean = thrust::raw_pointer_cast(voxel_means_ptr)[i];
     auto& voxel_covs = thrust::raw_pointer_cast(voxel_covs_ptr)[i];
+    auto& voxel_ints = thrust::raw_pointer_cast(voxel_intensities_ptr)[i];
 
     voxel_mean /= num_points;
     voxel_covs /= num_points;
+    //voxel_ints /= num_points;   //uncomment this line if you want to average the intensity values
   }
 
   thrust::device_ptr<int> num_points_ptr;
   thrust::device_ptr<Eigen::Vector3f> voxel_means_ptr;
   thrust::device_ptr<Eigen::Matrix3f> voxel_covs_ptr;
+  thrust::device_ptr<float> voxel_intensities_ptr; 
 };
 
 GaussianVoxelMapGPU::GaussianVoxelMapGPU(
@@ -175,7 +186,6 @@ GaussianVoxelMapGPU::GaussianVoxelMapGPU(
   voxelmap_info.num_buckets = init_num_buckets;
   voxelmap_info.max_bucket_scan_count = max_bucket_scan_count;
   voxelmap_info.voxel_resolution = resolution;
-
   check_error << cudaMallocAsync(&voxelmap_info_ptr, sizeof(VoxelMapInfo), stream);
   check_error << cudaMemcpyAsync(voxelmap_info_ptr, &voxelmap_info, sizeof(VoxelMapInfo), cudaMemcpyHostToDevice, stream);
 
@@ -184,6 +194,8 @@ GaussianVoxelMapGPU::GaussianVoxelMapGPU(
   num_points = nullptr;
   voxel_means = nullptr;
   voxel_covs = nullptr;
+  voxel_intensities = nullptr; 
+  
 }
 
 GaussianVoxelMapGPU::~GaussianVoxelMapGPU() {
@@ -192,6 +204,7 @@ GaussianVoxelMapGPU::~GaussianVoxelMapGPU() {
   check_error << cudaFreeAsync(num_points, 0);
   check_error << cudaFreeAsync(voxel_means, 0);
   check_error << cudaFreeAsync(voxel_covs, 0);
+  check_error << cudaFreeAsync(voxel_intensities, 0);
 }
 
 void GaussianVoxelMapGPU::insert(const PointCloud& frame) {
@@ -201,30 +214,28 @@ void GaussianVoxelMapGPU::insert(const PointCloud& frame) {
   }
 
   create_bucket_table(stream, frame);
-
   check_error << cudaMallocAsync(&num_points, sizeof(int) * voxelmap_info.num_voxels, stream);
   check_error << cudaMallocAsync(&voxel_means, sizeof(Eigen::Vector3f) * voxelmap_info.num_voxels, stream);
   check_error << cudaMallocAsync(&voxel_covs, sizeof(Eigen::Matrix3f) * voxelmap_info.num_voxels, stream);
-
+  check_error << cudaMallocAsync(&voxel_intensities, sizeof(float) * voxelmap_info.num_voxels, stream);
   check_error << cudaMemsetAsync(num_points, 0, sizeof(int) * voxelmap_info.num_voxels, stream);
   check_error << cudaMemsetAsync(voxel_means, 0, sizeof(Eigen::Vector3f) * voxelmap_info.num_voxels, stream);
   check_error << cudaMemsetAsync(voxel_covs, 0, sizeof(Eigen::Matrix3f) * voxelmap_info.num_voxels, stream);
-
+  check_error << cudaMemsetAsync(voxel_intensities, 0, sizeof(float) * voxelmap_info.num_voxels, stream);
   thrust::device_ptr<Eigen::Vector3f> points_ptr(frame.points_gpu);
   thrust::device_ptr<Eigen::Matrix3f> covs_ptr(frame.covs_gpu);
-
+  thrust::device_ptr<float> ints_ptr(frame.intensities_gpu);
   thrust::for_each(
     thrust::cuda::par_nosync.on(stream),
-    thrust::make_zip_iterator(thrust::make_tuple(points_ptr, covs_ptr)),
-    thrust::make_zip_iterator(thrust::make_tuple(points_ptr + frame.size(), covs_ptr + frame.size())),
-    accumulate_points_kernel(voxelmap_info_ptr, buckets, num_points, voxel_means, voxel_covs));
+    thrust::make_zip_iterator(thrust::make_tuple(points_ptr, covs_ptr, ints_ptr)),
+    thrust::make_zip_iterator(thrust::make_tuple(points_ptr + frame.size(), covs_ptr + frame.size(), ints_ptr + frame.size())),
+    accumulate_points_kernel(voxelmap_info_ptr, buckets, num_points, voxel_means, voxel_covs, voxel_intensities));
 
   thrust::for_each(
     thrust::cuda::par_nosync.on(stream),
     thrust::counting_iterator<int>(0),
     thrust::counting_iterator<int>(voxelmap_info.num_voxels),
-    finalize_voxels_kernel(num_points, voxel_means, voxel_covs));
-
+    finalize_voxels_kernel(num_points, voxel_means, voxel_covs, voxel_intensities));
   cudaStreamSynchronize(stream);
 }
 
@@ -244,7 +255,7 @@ void GaussianVoxelMapGPU::create_bucket_table(cudaStream_t stream, const PointCl
   check_error << cudaMallocAsync(&voxels_failures, sizeof(int) * 2, stream);
   check_error << cudaMemsetAsync(voxels_failures, 0, sizeof(int) * 2, stream);
 
-  for (int num_buckets = init_num_buckets; init_num_buckets * 4; num_buckets *= 2) {
+  for (int num_buckets = init_num_buckets; init_num_buckets * 4; num_buckets *= 2) {            
     voxelmap_info.num_buckets = num_buckets;
     check_error << cudaMemcpyAsync(voxelmap_info_ptr, &voxelmap_info, sizeof(VoxelMapInfo), cudaMemcpyHostToDevice, stream);
 
@@ -292,11 +303,13 @@ void GaussianVoxelMapGPU::save_compact(const std::string& path) const {
   std::vector<int> h_num_points(voxelmap_info.num_voxels);
   std::vector<Eigen::Vector3f> h_voxel_means(voxelmap_info.num_voxels);
   std::vector<Eigen::Matrix3f> h_voxel_covs(voxelmap_info.num_voxels);
+  std::vector<float> h_voxel_intensities(voxelmap_info.num_voxels);
 
   check_error << cudaMemcpyAsync(h_buckets.data(), buckets, sizeof(VoxelBucket) * voxelmap_info.num_buckets, cudaMemcpyDeviceToHost, 0);
   check_error << cudaMemcpyAsync(h_num_points.data(), num_points, sizeof(int) * voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, 0);
   check_error << cudaMemcpyAsync(h_voxel_means.data(), voxel_means, sizeof(Eigen::Vector3f) * voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, 0);
   check_error << cudaMemcpyAsync(h_voxel_covs.data(), voxel_covs, sizeof(Eigen::Matrix3f) * voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, 0);
+  check_error << cudaMemcpyAsync(h_voxel_intensities.data(), voxel_intensities, sizeof(float) * voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, 0);
 
   std::vector<GaussianVoxelData> serial_voxels;
   serial_voxels.reserve(voxelmap_info.num_voxels);
@@ -329,7 +342,9 @@ void GaussianVoxelMapGPU::save_compact(const std::string& path) const {
     voxel.mean = h_voxel_means[i].homogeneous().cast<double>();
     voxel.cov.setZero();
     voxel.cov.topLeftCorner<3, 3>() = h_voxel_covs[i].cast<double>();
+    voxel.intensity = h_voxel_intensities[i];
     serial_voxels.emplace_back(h_voxel_coords[i], voxel);
+    
   }
 
   std::ofstream ofs(path);
@@ -374,12 +389,15 @@ GaussianVoxelMapGPU::Ptr GaussianVoxelMapGPU::load(const std::string& path) {
   std::vector<int> h_num_points(num_voxels);
   std::vector<Eigen::Vector3f> h_voxel_means(num_voxels);
   std::vector<Eigen::Matrix3f> h_voxel_covs(num_voxels);
+  std::vector<float> h_voxel_intensities(num_voxels);
+
   for (int i = 0; i < num_voxels; i++) {
     const auto& info_voxel = flat_voxels[i].uncompact();
     h_coords[i] = info_voxel->first.coord;
     h_num_points[i] = info_voxel->second.num_points;
     h_voxel_means[i] = info_voxel->second.mean.head<3>().cast<float>();
     h_voxel_covs[i] = info_voxel->second.cov.topLeftCorner<3, 3>().cast<float>();
+    h_voxel_intensities[i] = info_voxel->second.intensity;
   }
 
   std::vector<VoxelBucket> h_buckets;
@@ -429,11 +447,12 @@ GaussianVoxelMapGPU::Ptr GaussianVoxelMapGPU::load(const std::string& path) {
   check_error << cudaMallocAsync(&voxelmap->num_points, sizeof(int) * num_voxels, 0);
   check_error << cudaMallocAsync(&voxelmap->voxel_means, sizeof(Eigen::Vector3f) * num_voxels, 0);
   check_error << cudaMallocAsync(&voxelmap->voxel_covs, sizeof(Eigen::Matrix3f) * num_voxels, 0);
+  check_error << cudaMallocAsync(&voxelmap->voxel_intensities, sizeof(float) * num_voxels, 0);
   check_error << cudaMemcpyAsync(voxelmap->buckets, h_buckets.data(), sizeof(VoxelBucket) * h_buckets.size(), cudaMemcpyHostToDevice, 0);
   check_error << cudaMemcpyAsync(voxelmap->num_points, h_num_points.data(), sizeof(int) * num_voxels, cudaMemcpyHostToDevice, 0);
   check_error << cudaMemcpyAsync(voxelmap->voxel_means, h_voxel_means.data(), sizeof(Eigen::Vector3f) * num_voxels, cudaMemcpyHostToDevice, 0);
   check_error << cudaMemcpyAsync(voxelmap->voxel_covs, h_voxel_covs.data(), sizeof(Eigen::Matrix3f) * num_voxels, cudaMemcpyHostToDevice, 0);
-
+  check_error << cudaMemcpyAsync(voxelmap->voxel_intensities, h_voxel_intensities.data(), sizeof(float) * num_voxels, cudaMemcpyHostToDevice, 0);
   return voxelmap;
 }
 
@@ -467,6 +486,13 @@ std::vector<Eigen::Matrix3f> download_voxel_covs(const GaussianVoxelMapGPU& voxe
   check_error
     << cudaMemcpyAsync(covs.data(), voxelmap.voxel_covs, sizeof(Eigen::Matrix3f) * voxelmap.voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, stream);
   return covs;
+}
+
+std::vector<float> download_voxel_intensities(const GaussianVoxelMapGPU& vm,  CUstream_st* stream) {
+  std::vector<float> ints(vm.voxelmap_info.num_voxels);
+  check_error 
+    << cudaMemcpyAsync(ints.data(), vm.voxel_intensities, sizeof(float) * vm.voxelmap_info.num_voxels, cudaMemcpyDeviceToHost, stream);
+  return ints;
 }
 
 }  // namespace gtsam_points

--- a/src/gtsam_points/types/gaussian_voxelmap_gpu_funcs.cu
+++ b/src/gtsam_points/types/gaussian_voxelmap_gpu_funcs.cu
@@ -64,6 +64,15 @@ PointCloud::Ptr merge_frames_gpu(
   check_error << cudaMallocAsync(&all_points, sizeof(Eigen::Vector3f) * num_all_points, stream);
   check_error << cudaMallocAsync(&all_covs, sizeof(Eigen::Matrix3f) * num_all_points, stream);
 
+  float* all_ints;
+  check_error << cudaMallocAsync(&all_ints, sizeof(float) * num_all_points, stream);
+
+  static float* d_zero = nullptr;
+  if (!d_zero) {
+    cudaMalloc(&d_zero, sizeof(float));
+    cudaMemset(d_zero, 0, sizeof(float));
+  }
+
   const thrust::device_ptr<Eigen::Vector3f> all_points_ptr(all_points);
   const thrust::device_ptr<Eigen::Matrix3f> all_covs_ptr(all_covs);
 
@@ -81,6 +90,18 @@ PointCloud::Ptr merge_frames_gpu(
       all_points_ptr + begin,
       transform_means_kernel(transform_ptr));
     thrust::transform(thrust::cuda::par.on(stream), covs_ptr, covs_ptr + frame->size(), all_covs_ptr + begin, transform_covs_kernel(transform_ptr));
+    if (frame->intensities_gpu) {
+      check_error << cudaMemcpyAsync(all_ints + begin,
+                                     frame->intensities_gpu,
+                                     sizeof(float) * frame->size(),
+                                     cudaMemcpyDeviceToDevice, stream);
+    } else {
+      check_error << cudaMemsetAsync(all_ints + begin,
+                                     0,
+                                     sizeof(float) * frame->size(),
+                                     stream);
+    }
+
     begin += frame->size();
   }
 
@@ -90,6 +111,7 @@ PointCloud::Ptr merge_frames_gpu(
   all_frames.num_points = num_all_points;
   all_frames.points_gpu = all_points;
   all_frames.covs_gpu = all_covs;
+  all_frames.intensities_gpu= all_ints;     
 
   GaussianVoxelMapGPU downsampling(downsample_resolution, num_all_points, 10, 1e-3, stream);
   downsampling.insert(all_frames);
@@ -97,21 +119,26 @@ PointCloud::Ptr merge_frames_gpu(
   const int num_voxels = downsampling.voxelmap_info.num_voxels;
   const Eigen::Vector3f* voxel_means = downsampling.voxel_means;
   const Eigen::Matrix3f* voxel_covs = downsampling.voxel_covs;
+  float* voxel_intensities = downsampling.voxel_intensities;
 
   std::vector<Eigen::Vector3f> means(num_voxels);
   std::vector<Eigen::Matrix3f> covs(num_voxels);
+  std::vector<float> intensities(num_voxels);
 
   check_error << cudaMemcpyAsync(means.data(), voxel_means, sizeof(Eigen::Vector3f) * num_voxels, cudaMemcpyDeviceToHost, stream);
   check_error << cudaMemcpyAsync(covs.data(), voxel_covs, sizeof(Eigen::Matrix3f) * num_voxels, cudaMemcpyDeviceToHost, stream);
+  check_error << cudaMemcpyAsync(intensities.data(), downsampling.voxel_intensities, sizeof(float) * num_voxels, cudaMemcpyDeviceToHost, stream);
   check_error << cudaStreamSynchronize(stream);
 
   check_error << cudaFreeAsync(d_poses, stream);
   check_error << cudaFreeAsync(all_points, stream);
   check_error << cudaFreeAsync(all_covs, stream);
+  check_error << cudaFreeAsync(all_ints,  stream);
 
   auto merged = std::make_shared<PointCloudGPU>();
   merged->add_points(means, stream);
   merged->add_covs(covs, stream);
+  merged->add_intensities(intensities, stream);
 
   return merged;
 }


### PR DESCRIPTION
This PR adds support for LiDAR intensity values in the GPU-based point cloud processing modules. The key updates are:

- Addition of an `intensity` field to `GaussianVoxelData`.
- Maximum intensity value for each voxel is propagated (optionally averaging can also be applied).