### PR TITLE
Add transform-reduce extension points for CUDA VGICP derivatives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ if(BUILD_WITH_CUDA)
   )
   set_target_properties(gtsam_points_cuda PROPERTIES
     VERSION   ${PROJECT_VERSION}
-    SOVERSION 1
+    SOVERSION 2
   )
 
   target_link_libraries(gtsam_points
@@ -350,6 +350,14 @@ if(BUILD_TESTS)
     target_include_directories(${test_name} PRIVATE ${Boost_INCLUDE_DIRS} src/test/include)
     gtest_discover_tests(${test_name} WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
   endforeach()
+
+  if(BUILD_WITH_CUDA)
+    set(test_name test_vgicp_derivatives_transform_reduce)
+    add_executable(${test_name} src/test/test_vgicp_derivatives_transform_reduce.cu)
+    target_link_libraries(${test_name} gtsam_points gtest_main)
+    target_include_directories(${test_name} PRIVATE ${Boost_INCLUDE_DIRS} src/test/include)
+    gtest_discover_tests(${test_name} WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+  endif()
 
   if(BUILD_TESTS_PCL)
     enable_language(C)

--- a/include/gtsam_points/factors/impl/integrated_vgicp_derivatives_impl.cuh
+++ b/include/gtsam_points/factors/impl/integrated_vgicp_derivatives_impl.cuh
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021  Kenji Koide (k.koide@aist.go.jp)
+
+#pragma once
+
+#include <thrust/functional.h>
+#include <thrust/iterator/transform_iterator.h>
+
+#include <cub/device/device_reduce.cuh>
+
+#include <gtsam_points/cuda/kernels/lookup_voxels.cuh>
+#include <gtsam_points/cuda/kernels/vgicp_derivatives.cuh>
+#include <gtsam_points/cuda/stream_temp_buffer_roundrobin.hpp>
+
+namespace gtsam_points {
+namespace detail {
+
+template <typename Result, typename Transform>
+struct transform_vgicp_linearization {
+  transform_vgicp_linearization(vgicp_derivatives_kernel derivatives, Transform transform, const Result& identity)
+  : derivatives(derivatives), transform(transform), identity(identity) {}
+
+  __device__ Result operator()(const thrust::pair<int, int>& correspondence) const {
+    if (correspondence.first < 0 || correspondence.second < 0) {
+      return identity;
+    }
+
+    return transform(correspondence, derivatives(correspondence));
+  }
+
+  vgicp_derivatives_kernel derivatives;
+  Transform transform;
+  Result identity;
+};
+
+template <typename Result, typename Transform>
+struct transform_vgicp_error {
+  transform_vgicp_error(vgicp_error_kernel error, Transform transform, const Result& identity)
+  : error(error), transform(transform), identity(identity) {}
+
+  __device__ Result operator()(const thrust::pair<int, int>& correspondence) const {
+    if (correspondence.first < 0 || correspondence.second < 0) {
+      return identity;
+    }
+
+    return transform(correspondence, error(correspondence));
+  }
+
+  vgicp_error_kernel error;
+  Transform transform;
+  Result identity;
+};
+
+}  // namespace detail
+
+template <typename Result, typename Transform, typename Reduction>
+void IntegratedVGICPDerivatives::issue_linearize_transform_reduce(
+  const Eigen::Isometry3f* d_x,
+  Result* d_output,
+  Transform transform,
+  Reduction reduction,
+  const Result& identity) {
+  //
+  lookup_voxels_kernel correspondence_lookup(enable_surface_validation, *target, source->points_gpu, source->normals_gpu, d_x);
+  auto correspondences = thrust::make_transform_iterator(source_inliers, correspondence_lookup);
+
+  vgicp_derivatives_kernel derivatives(d_x, *target, source->points_gpu, source->covs_gpu);
+  detail::transform_vgicp_linearization<Result, Transform> transformed_derivatives(derivatives, transform, identity);
+  auto first = thrust::make_transform_iterator(correspondences, transformed_derivatives);
+
+  void* temp_storage = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, reduction, identity, stream);
+
+  temp_storage = temp_buffer->get_buffer(temp_storage_bytes);
+  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, reduction, identity, stream);
+}
+
+template <typename Result, typename Transform>
+void IntegratedVGICPDerivatives::issue_linearize_transform_reduce(
+  const Eigen::Isometry3f* d_x,
+  Result* d_output,
+  Transform transform,
+  const Result& identity) {
+  //
+  issue_linearize_transform_reduce(d_x, d_output, transform, thrust::plus<Result>(), identity);
+}
+
+template <typename Result, typename Transform, typename Reduction>
+void IntegratedVGICPDerivatives::issue_compute_error_transform_reduce(
+  const Eigen::Isometry3f* d_xl,
+  const Eigen::Isometry3f* d_xe,
+  Result* d_output,
+  Transform transform,
+  Reduction reduction,
+  const Result& identity) {
+  //
+  lookup_voxels_kernel correspondence_lookup(
+    enable_surface_validation,
+    *target,
+    source->points_gpu,
+    source->normals_gpu,
+    d_xl);
+  auto correspondences = thrust::make_transform_iterator(source_inliers, correspondence_lookup);
+
+  vgicp_error_kernel error(d_xl, d_xe, *target, source->points_gpu, source->covs_gpu);
+  detail::transform_vgicp_error<Result, Transform> transformed_error(error, transform, identity);
+  auto first = thrust::make_transform_iterator(correspondences, transformed_error);
+
+  void* temp_storage = nullptr;
+  size_t temp_storage_bytes = 0;
+
+  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, reduction, identity, stream);
+
+  temp_storage = temp_buffer->get_buffer(temp_storage_bytes);
+  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, reduction, identity, stream);
+}
+
+template <typename Result, typename Transform>
+void IntegratedVGICPDerivatives::issue_compute_error_transform_reduce(
+  const Eigen::Isometry3f* d_xl,
+  const Eigen::Isometry3f* d_xe,
+  Result* d_output,
+  Transform transform,
+  const Result& identity) {
+  //
+  issue_compute_error_transform_reduce(d_xl, d_xe, d_output, transform, thrust::plus<Result>(), identity);
+}
+
+}  // namespace gtsam_points

--- a/include/gtsam_points/factors/integrated_vgicp_derivatives.cuh
+++ b/include/gtsam_points/factors/integrated_vgicp_derivatives.cuh
@@ -25,7 +25,7 @@ public:
     const PointCloud::ConstPtr& source,
     CUstream_st* ext_stream,
     std::shared_ptr<TempBufferManager> temp_buffer);
-  ~IntegratedVGICPDerivatives();
+  virtual ~IntegratedVGICPDerivatives();
 
   void set_inlier_update_thresh(double trans, double angle) {
     inlier_update_thresh_trans = trans;
@@ -49,8 +49,71 @@ public:
 
   // async interface
   void sync_stream();
-  void issue_linearize(const Eigen::Isometry3f* d_x, LinearizedSystem6* d_output);
-  void issue_compute_error(const Eigen::Isometry3f* d_xl, const Eigen::Isometry3f* d_xe, float* d_output);
+  virtual void issue_linearize(const Eigen::Isometry3f* d_x, LinearizedSystem6* d_output);
+  virtual void issue_compute_error(const Eigen::Isometry3f* d_xl, const Eigen::Isometry3f* d_xe, float* d_output);
+
+protected:
+  /// @brief Get the CUDA stream used by this derivatives instance.
+  CUstream_st* cuda_stream() const { return stream; }
+
+  /**
+   * @brief Apply a custom device transform to each valid VGICP correspondence after standard linearization and reduce the results.
+   *
+   * Transform must be device-callable with the following signature:
+   * @code
+   * Result operator()(const thrust::pair<int, int>& correspondence, const LinearizedSystem6& linearized) const;
+   * @endcode
+   * Invalid correspondences are mapped directly to identity and are never passed to Transform.
+   * Reduction must be device-callable and identity must be its neutral element.
+   * Transform must preserve LinearizedSystem6::num_inliers when its result contains the system used by
+   * IntegratedVGICPFactorGPU, because the count is also used to maintain the inlier index buffer.
+   */
+  template <typename Result, typename Transform, typename Reduction>
+  void issue_linearize_transform_reduce(
+    const Eigen::Isometry3f* d_x,
+    Result* d_output,
+    Transform transform,
+    Reduction reduction,
+    const Result& identity);
+
+  /**
+   * @brief Additive convenience overload of issue_linearize_transform_reduce().
+   */
+  template <typename Result, typename Transform>
+  void issue_linearize_transform_reduce(
+    const Eigen::Isometry3f* d_x,
+    Result* d_output,
+    Transform transform,
+    const Result& identity);
+
+  /**
+   * @brief Apply a custom device transform to each valid VGICP correspondence error and reduce the results.
+   *
+   * Transform must be device-callable with the following signature:
+   * @code
+   * Result operator()(const thrust::pair<int, int>& correspondence, float error) const;
+   * @endcode
+   * Invalid correspondences are mapped directly to identity and are never passed to Transform.
+   */
+  template <typename Result, typename Transform, typename Reduction>
+  void issue_compute_error_transform_reduce(
+    const Eigen::Isometry3f* d_xl,
+    const Eigen::Isometry3f* d_xe,
+    Result* d_output,
+    Transform transform,
+    Reduction reduction,
+    const Result& identity);
+
+  /**
+   * @brief Additive convenience overload of issue_compute_error_transform_reduce().
+   */
+  template <typename Result, typename Transform>
+  void issue_compute_error_transform_reduce(
+    const Eigen::Isometry3f* d_xl,
+    const Eigen::Isometry3f* d_xe,
+    Result* d_output,
+    Transform transform,
+    const Result& identity);
 
 private:
   bool enable_offloading;
@@ -74,3 +137,7 @@ private:
   int* source_inliers;
 };
 }  // namespace gtsam_points
+
+#if defined(__CUDACC__)
+#include <gtsam_points/factors/impl/integrated_vgicp_derivatives_impl.cuh>
+#endif

--- a/include/gtsam_points/factors/integrated_vgicp_factor_gpu.hpp
+++ b/include/gtsam_points/factors/integrated_vgicp_factor_gpu.hpp
@@ -135,6 +135,16 @@ public:
 
   virtual void sync() override;
 
+protected:
+  /**
+   * @brief Replace the derivatives implementation used by this factor.
+   * @note This is intended for derived factors that install a custom implementation during construction.
+   * @warning A derived factor that calls this function must override clone() and reinstall an equivalent
+   *          derivatives implementation in the cloned factor. The inherited clone() rejects custom derivatives
+   *          to prevent silently reverting to the standard implementation.
+   */
+  void replace_derivatives(std::unique_ptr<IntegratedVGICPDerivatives> replacement);
+
 private:
   Eigen::Isometry3f calc_delta(const gtsam::Values& values) const;
 

--- a/src/gtsam_points/factors/integrated_vgicp_derivatives_compute.cu
+++ b/src/gtsam_points/factors/integrated_vgicp_derivatives_compute.cu
@@ -3,39 +3,20 @@
 
 #include <gtsam_points/factors/integrated_vgicp_derivatives.cuh>
 
-#include <iostream>
-#include <thrust/remove.h>
-#include <thrust/iterator/transform_iterator.h>
-
-#include <cub/device/device_reduce.cuh>
-
-#include <gtsam_points/cuda/kernels/pose.cuh>
-#include <gtsam_points/cuda/kernels/untie.cuh>
-#include <gtsam_points/cuda/kernels/lookup_voxels.cuh>
-#include <gtsam_points/cuda/kernels/linearized_system.cuh>
-#include <gtsam_points/cuda/kernels/vgicp_derivatives.cuh>
-#include <gtsam_points/cuda/stream_temp_buffer_roundrobin.hpp>
-
-#include <gtsam_points/types/gaussian_voxelmap_gpu.hpp>
+#include <thrust/pair.h>
 
 namespace gtsam_points {
 
+namespace {
+
+struct identity_error_transform {
+  __device__ float operator()(const thrust::pair<int, int>&, float error) const { return error; }
+};
+
+}  // namespace
+
 void IntegratedVGICPDerivatives::issue_compute_error(const Eigen::Isometry3f* d_xl, const Eigen::Isometry3f* d_xe, float* d_output) {
-  //
-  lookup_voxels_kernel corr_kernel(enable_surface_validation, *target, source->points_gpu, source->normals_gpu, d_xl);
-  auto corr_first = thrust::make_transform_iterator(source_inliers, corr_kernel);
-
-  vgicp_error_kernel error_kernel(d_xl, d_xe, *target, source->points_gpu, source->covs_gpu);
-  auto first = thrust::make_transform_iterator(corr_first, error_kernel);
-
-  void* temp_storage = nullptr;
-  size_t temp_storage_bytes = 0;
-
-  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, thrust::plus<float>(), 0.0f, stream);
-
-  temp_storage = temp_buffer->get_buffer(temp_storage_bytes);
-
-  cub::DeviceReduce::Reduce(temp_storage, temp_storage_bytes, first, d_output, num_inliers, thrust::plus<float>(), 0.0f, stream);
+  issue_compute_error_transform_reduce(d_xl, d_xe, d_output, identity_error_transform(), 0.0f);
 }
 
 }  // namespace gtsam_points

--- a/src/gtsam_points/factors/integrated_vgicp_derivatives_linearize.cu
+++ b/src/gtsam_points/factors/integrated_vgicp_derivatives_linearize.cu
@@ -3,55 +3,25 @@
 
 #include <gtsam_points/factors/integrated_vgicp_derivatives.cuh>
 
-#include <iostream>
-#include <thrust/remove.h>
-#include <thrust/iterator/transform_iterator.h>
-
-#include <cub/device/device_reduce.cuh>
-
-#include <gtsam_points/cuda/kernels/pose.cuh>
-#include <gtsam_points/cuda/kernels/untie.cuh>
-#include <gtsam_points/cuda/kernels/lookup_voxels.cuh>
 #include <gtsam_points/cuda/kernels/linearized_system.cuh>
-#include <gtsam_points/cuda/kernels/vgicp_derivatives.cuh>
-#include <gtsam_points/cuda/stream_temp_buffer_roundrobin.hpp>
-
-#include <gtsam_points/types/gaussian_voxelmap_gpu.hpp>
 
 namespace gtsam_points {
 
+namespace {
+
+struct identity_linearization_transform {
+  __device__ LinearizedSystem6 operator()(
+    const thrust::pair<int, int>&,
+    const LinearizedSystem6& linearized) const {
+    //
+    return linearized;
+  }
+};
+
+}  // namespace
+
 void IntegratedVGICPDerivatives::issue_linearize(const Eigen::Isometry3f* d_x, LinearizedSystem6* d_output) {
-  //
-  lookup_voxels_kernel corr_kernel(enable_surface_validation, *target, source->points_gpu, source->normals_gpu, d_x);
-  auto corr_first = thrust::make_transform_iterator(source_inliers, corr_kernel);
-
-  vgicp_derivatives_kernel deriv_kernel(d_x, *target, source->points_gpu, source->covs_gpu);
-  auto first = thrust::make_transform_iterator(corr_first, deriv_kernel);
-
-  void* temp_storage = nullptr;
-  size_t temp_storage_bytes = 0;
-
-  cub::DeviceReduce::Reduce(
-    temp_storage,
-    temp_storage_bytes,
-    first,
-    d_output,
-    num_inliers,
-    thrust::plus<LinearizedSystem6>(),
-    LinearizedSystem6::zero(),
-    stream);
-
-  temp_storage = temp_buffer->get_buffer(temp_storage_bytes);
-
-  cub::DeviceReduce::Reduce(
-    temp_storage,
-    temp_storage_bytes,
-    first,
-    d_output,
-    num_inliers,
-    thrust::plus<LinearizedSystem6>(),
-    LinearizedSystem6::zero(),
-    stream);
+  issue_linearize_transform_reduce(d_x, d_output, identity_linearization_transform(), LinearizedSystem6::zero());
 }
 
 }  // namespace gtsam_points

--- a/src/gtsam_points/factors/integrated_vgicp_factor_gpu.cpp
+++ b/src/gtsam_points/factors/integrated_vgicp_factor_gpu.cpp
@@ -3,6 +3,10 @@
 
 #include <gtsam_points/factors/integrated_vgicp_factor_gpu.hpp>
 
+#include <stdexcept>
+#include <typeinfo>
+#include <utility>
+
 #include <cuda_runtime.h>
 
 #include <gtsam/geometry/Pose3.h>
@@ -120,6 +124,11 @@ double IntegratedVGICPFactorGPU::inlier_fraction() const {
 }
 
 gtsam::NonlinearFactor::shared_ptr IntegratedVGICPFactorGPU::clone() const {
+  if (typeid(*derivatives) != typeid(IntegratedVGICPDerivatives)) {
+    throw std::logic_error(
+      "A derived IntegratedVGICPFactorGPU with custom derivatives must override clone() and reinstall them");
+  }
+
   if (is_binary) {
     return gtsam::make_shared<IntegratedVGICPFactorGPU>(keys()[0], keys()[1], target, source, nullptr, nullptr);
   }
@@ -269,5 +278,13 @@ void IntegratedVGICPFactorGPU::store_computed_error(const void* eval_output_cpu)
 
 void IntegratedVGICPFactorGPU::sync() {
   derivatives->sync_stream();
+}
+
+void IntegratedVGICPFactorGPU::replace_derivatives(std::unique_ptr<IntegratedVGICPDerivatives> replacement) {
+  if (!replacement) {
+    throw std::invalid_argument("IntegratedVGICPFactorGPU derivatives replacement must not be null");
+  }
+
+  derivatives = std::move(replacement);
 }
 }  // namespace gtsam_points

--- a/src/test/test_vgicp_derivatives_transform_reduce.cu
+++ b/src/test/test_vgicp_derivatives_transform_reduce.cu
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <thrust/device_vector.h>
+#include <thrust/pair.h>
+
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/linear/GaussianFactor.h>
+#include <gtsam/nonlinear/Values.h>
+
+#include <gtsam_points/cuda/nonlinear_factor_set_gpu.hpp>
+#include <gtsam_points/cuda/kernels/linearized_system.cuh>
+#include <gtsam_points/factors/integrated_vgicp_derivatives.cuh>
+#include <gtsam_points/factors/integrated_vgicp_factor_gpu.hpp>
+#include <gtsam_points/types/gaussian_voxelmap_gpu.hpp>
+#include <gtsam_points/types/point_cloud_gpu.hpp>
+#include <gtsam_points/util/gtsam_migration.hpp>
+
+namespace gtsam_points {
+namespace {
+
+struct LinearizationStats {
+  __host__ __device__ LinearizationStats operator+(const LinearizationStats& rhs) const {
+    LinearizationStats sum;
+    sum.system = system + rhs.system;
+    sum.transformed_count = transformed_count + rhs.transformed_count;
+    sum.source_index_sum = source_index_sum + rhs.source_index_sum;
+    return sum;
+  }
+
+  __host__ __device__ static LinearizationStats zero() {
+    LinearizationStats result;
+    result.system = LinearizedSystem6::zero();
+    result.transformed_count = 0;
+    result.source_index_sum = 0;
+    return result;
+  }
+
+  LinearizedSystem6 system;
+  int transformed_count;
+  int source_index_sum;
+};
+
+struct ErrorStats {
+  __host__ __device__ ErrorStats operator+(const ErrorStats& rhs) const {
+    return {error + rhs.error, transformed_count + rhs.transformed_count, source_index_sum + rhs.source_index_sum};
+  }
+
+  float error;
+  int transformed_count;
+  int source_index_sum;
+};
+
+struct collect_linearization_stats {
+  __device__ LinearizationStats operator()(
+    const thrust::pair<int, int>& correspondence,
+    const LinearizedSystem6& linearized) const {
+    //
+    LinearizationStats result;
+    result.system = linearized;
+    result.transformed_count = 1;
+    result.source_index_sum = correspondence.first;
+    return result;
+  }
+};
+
+struct collect_error_stats {
+  __device__ ErrorStats operator()(const thrust::pair<int, int>& correspondence, float error) const {
+    return {error, 1, correspondence.first};
+  }
+};
+
+struct scale_linearization {
+  explicit scale_linearization(float scale) : scale(scale) {}
+
+  __device__ LinearizedSystem6 operator()(
+    const thrust::pair<int, int>&,
+    const LinearizedSystem6& linearized) const {
+    //
+    LinearizedSystem6 scaled = linearized;
+    scaled.error *= scale;
+    scaled.H_target *= scale;
+    scaled.H_source *= scale;
+    scaled.H_target_source *= scale;
+    scaled.b_target *= scale;
+    scaled.b_source *= scale;
+    return scaled;
+  }
+
+  float scale;
+};
+
+struct scale_error {
+  explicit scale_error(float scale) : scale(scale) {}
+
+  __device__ float operator()(const thrust::pair<int, int>&, float error) const { return scale * error; }
+
+  float scale;
+};
+
+class InspectableVGICPDerivatives : public IntegratedVGICPDerivatives {
+public:
+  using IntegratedVGICPDerivatives::IntegratedVGICPDerivatives;
+
+  LinearizationStats linearize_with_stats(const Eigen::Isometry3f& x) {
+    thrust::device_vector<Eigen::Isometry3f> x_device(1);
+    thrust::device_vector<LinearizationStats> output_device(1);
+    x_device[0] = x;
+
+    const auto x_ptr = thrust::raw_pointer_cast(x_device.data());
+    reset_inliers(x, x_ptr);
+    issue_linearize_transform_reduce(
+      x_ptr,
+      thrust::raw_pointer_cast(output_device.data()),
+      collect_linearization_stats(),
+      LinearizationStats::zero());
+    sync_stream();
+    return output_device[0];
+  }
+
+  ErrorStats compute_error_with_stats(const Eigen::Isometry3f& xl, const Eigen::Isometry3f& xe) {
+    thrust::device_vector<Eigen::Isometry3f> x_device(2);
+    thrust::device_vector<ErrorStats> output_device(1);
+    x_device[0] = xl;
+    x_device[1] = xe;
+
+    issue_compute_error_transform_reduce(
+      thrust::raw_pointer_cast(x_device.data()),
+      thrust::raw_pointer_cast(x_device.data() + 1),
+      thrust::raw_pointer_cast(output_device.data()),
+      collect_error_stats(),
+      ErrorStats{0.0f, 0, 0});
+    sync_stream();
+    return output_device[0];
+  }
+};
+
+class ScalingVGICPDerivatives : public IntegratedVGICPDerivatives {
+public:
+  ScalingVGICPDerivatives(
+    const GaussianVoxelMapGPU::ConstPtr& target,
+    const PointCloud::ConstPtr& source,
+    float scale)
+  : IntegratedVGICPDerivatives(target, source, nullptr, nullptr), scale(scale) {}
+
+  void issue_linearize(const Eigen::Isometry3f* d_x, LinearizedSystem6* d_output) override {
+    issue_linearize_transform_reduce(d_x, d_output, scale_linearization(scale), LinearizedSystem6::zero());
+  }
+
+  void issue_compute_error(const Eigen::Isometry3f* d_xl, const Eigen::Isometry3f* d_xe, float* d_output) override {
+    issue_compute_error_transform_reduce(d_xl, d_xe, d_output, scale_error(scale), 0.0f);
+  }
+
+private:
+  float scale;
+};
+
+class ScalingVGICPFactor : public IntegratedVGICPFactorGPU {
+public:
+  ScalingVGICPFactor(
+    const gtsam::Pose3& fixed_target_pose,
+    gtsam::Key source_key,
+    const GaussianVoxelMapGPU::ConstPtr& target,
+    const PointCloud::ConstPtr& source,
+    float scale)
+  : IntegratedVGICPFactorGPU(fixed_target_pose, source_key, target, source), source(source), scale(scale) {
+    replace_derivatives(std::make_unique<ScalingVGICPDerivatives>(target, source, scale));
+  }
+
+  gtsam_points::shared_ptr<gtsam::NonlinearFactor> clone() const override {
+    return gtsam::make_shared<ScalingVGICPFactor>(
+      gtsam::Pose3(get_fixed_target_pose().cast<double>().matrix()),
+      keys()[0],
+      get_target(),
+      source,
+      scale);
+  }
+
+private:
+  PointCloud::ConstPtr source;
+  float scale;
+};
+
+class NonCloningScalingVGICPFactor : public IntegratedVGICPFactorGPU {
+public:
+  NonCloningScalingVGICPFactor(
+    const gtsam::Pose3& fixed_target_pose,
+    gtsam::Key source_key,
+    const GaussianVoxelMapGPU::ConstPtr& target,
+    const PointCloud::ConstPtr& source,
+    float scale)
+  : IntegratedVGICPFactorGPU(fixed_target_pose, source_key, target, source) {
+    replace_derivatives(std::make_unique<ScalingVGICPDerivatives>(target, source, scale));
+  }
+};
+
+class VGICPDerivativesTransformReduceTest : public testing::Test {
+protected:
+  void SetUp() override {
+    int device_count = 0;
+    const cudaError_t status = cudaGetDeviceCount(&device_count);
+    if (status != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA device unavailable: " << cudaGetErrorString(status);
+    }
+
+    const std::vector<Eigen::Vector3f> target_points{
+      Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+      Eigen::Vector3f(2.0f, 0.0f, 0.0f),
+      Eigen::Vector3f(4.0f, 0.0f, 0.0f),
+      Eigen::Vector3f(6.0f, 0.0f, 0.0f),
+    };
+    std::vector<Eigen::Matrix3f> target_covs(target_points.size(), 0.05f * Eigen::Matrix3f::Identity());
+
+    auto target_frame = std::make_shared<PointCloudGPU>(target_points);
+    target_frame->add_covs(target_covs);
+
+    auto target_gpu = std::make_shared<GaussianVoxelMapGPU>(1.0f);
+    target_gpu->insert(*target_frame);
+    target = target_gpu;
+
+    std::vector<Eigen::Vector3f> source_points = target_points;
+    source_points.emplace_back(100.0f, 100.0f, 100.0f);
+    std::vector<Eigen::Matrix3f> source_covs(source_points.size(), 0.05f * Eigen::Matrix3f::Identity());
+
+    auto source_gpu = std::make_shared<PointCloudGPU>(source_points);
+    source_gpu->add_covs(source_covs);
+    source = source_gpu;
+  }
+
+  GaussianVoxelMapGPU::ConstPtr target;
+  PointCloud::ConstPtr source;
+};
+
+TEST_F(VGICPDerivativesTransformReduceTest, CustomResultsRetainContextAndDefaultValues) {
+  InspectableVGICPDerivatives derivatives(target, source, nullptr, nullptr);
+  const Eigen::Isometry3f identity = Eigen::Isometry3f::Identity();
+
+  const LinearizedSystem6 standard = derivatives.linearize(identity);
+  const LinearizationStats transformed = derivatives.linearize_with_stats(identity);
+
+  EXPECT_EQ(transformed.system.num_inliers, standard.num_inliers);
+  EXPECT_FLOAT_EQ(transformed.system.error, standard.error);
+  EXPECT_TRUE(transformed.system.H_target.isApprox(standard.H_target));
+  EXPECT_TRUE(transformed.system.H_source.isApprox(standard.H_source));
+  EXPECT_TRUE(transformed.system.H_target_source.isApprox(standard.H_target_source));
+  EXPECT_TRUE(transformed.system.b_target.isApprox(standard.b_target));
+  EXPECT_TRUE(transformed.system.b_source.isApprox(standard.b_source));
+
+  EXPECT_EQ(transformed.transformed_count, 4);
+  EXPECT_EQ(transformed.transformed_count, transformed.system.num_inliers);
+  EXPECT_EQ(transformed.source_index_sum, 0 + 1 + 2 + 3);
+
+  Eigen::Isometry3f evaluation = Eigen::Isometry3f::Identity();
+  evaluation.translation().x() = 0.1f;
+  const float standard_error = derivatives.compute_error(identity, evaluation);
+  const ErrorStats transformed_error = derivatives.compute_error_with_stats(identity, evaluation);
+
+  EXPECT_NEAR(transformed_error.error, standard_error, 1e-5f);
+  EXPECT_EQ(transformed_error.transformed_count, transformed.transformed_count);
+  EXPECT_EQ(transformed_error.source_index_sum, transformed.source_index_sum);
+}
+
+TEST_F(VGICPDerivativesTransformReduceTest, ReplacedDerivativesApplyToSynchronousFactorPaths) {
+  constexpr float scale = 2.0f;
+  IntegratedVGICPFactorGPU standard(gtsam::Pose3(), 0, target, source);
+  ScalingVGICPFactor transformed(gtsam::Pose3(), 0, target, source, scale);
+
+  Eigen::Isometry3d source_pose = Eigen::Isometry3d::Identity();
+  source_pose.translation().x() = 0.1;
+  gtsam::Values values;
+  values.insert(0, gtsam::Pose3(source_pose.matrix()));
+
+  const auto standard_linear = standard.linearize(values);
+  const auto transformed_linear = transformed.linearize(values);
+  EXPECT_TRUE(transformed_linear->information().isApprox(scale * standard_linear->information(), 1e-5));
+
+  const double standard_error = standard.error(values);
+  const double transformed_error = transformed.error(values);
+  EXPECT_GT(standard_error, 0.0);
+  EXPECT_NEAR(transformed_error, scale * standard_error, 1e-5);
+}
+
+TEST_F(VGICPDerivativesTransformReduceTest, ClonePreservesReplacedDerivatives) {
+  constexpr float scale = 2.0f;
+  auto original = gtsam::make_shared<ScalingVGICPFactor>(gtsam::Pose3(), 0, target, source, scale);
+  const auto cloned = gtsam_points::dynamic_pointer_cast<ScalingVGICPFactor>(original->clone());
+  ASSERT_TRUE(cloned);
+
+  Eigen::Isometry3d source_pose = Eigen::Isometry3d::Identity();
+  source_pose.translation().x() = 0.1;
+  gtsam::Values values;
+  values.insert(0, gtsam::Pose3(source_pose.matrix()));
+
+  const auto original_linear = original->linearize(values);
+  const auto cloned_linear = cloned->linearize(values);
+  EXPECT_TRUE(cloned_linear->information().isApprox(original_linear->information(), 1e-5));
+  EXPECT_NEAR(cloned->error(values), original->error(values), 1e-5);
+}
+
+TEST_F(VGICPDerivativesTransformReduceTest, InheritedCloneRejectsReplacedDerivatives) {
+  NonCloningScalingVGICPFactor factor(gtsam::Pose3(), 0, target, source, 2.0f);
+  EXPECT_THROW(factor.clone(), std::logic_error);
+}
+
+TEST_F(VGICPDerivativesTransformReduceTest, ReplacedDerivativesApplyToAsynchronousFactorPaths) {
+  constexpr float scale = 2.0f;
+  auto standard = gtsam::make_shared<IntegratedVGICPFactorGPU>(gtsam::Pose3(), 0, target, source);
+  auto transformed = gtsam::make_shared<ScalingVGICPFactor>(gtsam::Pose3(), 1, target, source, scale);
+
+  Eigen::Isometry3d source_pose = Eigen::Isometry3d::Identity();
+  source_pose.translation().x() = 0.1;
+  gtsam::Values values;
+  values.insert(0, gtsam::Pose3(source_pose.matrix()));
+  values.insert(1, gtsam::Pose3(source_pose.matrix()));
+
+  NonlinearFactorSetGPU factor_set;
+  ASSERT_TRUE(factor_set.add(standard));
+  ASSERT_TRUE(factor_set.add(transformed));
+
+  factor_set.linearize(values);
+  const auto standard_linear = standard->linearize(values);
+  const auto transformed_linear = transformed->linearize(values);
+  EXPECT_TRUE(transformed_linear->information().isApprox(scale * standard_linear->information(), 1e-5));
+
+  factor_set.error(values);
+  const double standard_error = standard->error(values);
+  const double transformed_error = transformed->error(values);
+  EXPECT_GT(standard_error, 0.0);
+  EXPECT_NEAR(transformed_error, scale * standard_error, 1e-5);
+}
+
+}  // namespace
+}  // namespace gtsam_points


### PR DESCRIPTION
### Summary

This PR adds an extension point to the CUDA VGICP derivative pipeline so downstream implementations can customize how individual correspondences contribute to the final reduction without duplicating correspondence lookup, VGICP derivative evaluation, CUDA stream handling, or CUB reduction logic.

Custom transforms are applied after the standard VGICP derivative/error computation and before reduction. They receive the source/target correspondence indices and can produce arbitrary reduction result types.

This enables use cases such as:

- Robust loss functions
- Per-correspondence weighting or filtering
- Semantic or application-specific correspondence weighting
- Custom reduction accumulators and diagnostics

The transforms are fused into the existing transform-reduce pipeline and do not require materializing per-correspondence derivative results.

### What changed

- Make `IntegratedVGICPDerivatives` polymorphic:
  - Add a virtual destructor
  - Make `issue_linearize()` and `issue_compute_error()` virtual
- Add protected CUDA transform-reduce helpers for linearization and error evaluation:
  - Transforms receive the source/target correspondence indices
  - Custom result types, reduction operators, and identity values are supported
  - Invalid correspondences bypass the transform and reduce to the supplied identity value
- Expose the CUDA stream to derived derivative implementations
- Add `IntegratedVGICPFactorGPU::replace_derivatives()` for derived factors
- Preserve the existing VGICP implementation through identity transforms
- Require factors with custom derivatives to override `clone()` so cloning cannot silently restore the default implementation
- Bump the `gtsam_points_cuda` `SOVERSION` because making `IntegratedVGICPDerivatives` polymorphic changes its ABI
- Add CUDA tests covering:
  - Custom transform/reduction results
  - Synchronous and asynchronous factor paths
  - Correct cloning behavior
  - Rejection of inherited cloning with replaced derivatives
  - Graceful skipping when no CUDA device is available

### Minimal usage example

The following example applies a Cauchy loss to each VGICP correspondence.

The derived implementation only defines how each already-computed VGICP correspondence contributes to the reduction. Correspondence lookup and the standard VGICP derivative/error evaluation remain in `gtsam_points`.

```cpp
#include <cmath>
#include <memory>

#include <thrust/pair.h>

#include <gtsam/geometry/Pose3.h>

#include <gtsam_points/cuda/kernels/linearized_system.cuh>
#include <gtsam_points/factors/integrated_vgicp_derivatives.cuh>
#include <gtsam_points/factors/integrated_vgicp_factor_gpu.hpp>

namespace gp = gtsam_points;

struct CauchyLinearization {
  float scale_sq;

  __device__ gp::LinearizedSystem6 operator()(
    const thrust::pair<int, int>&,
    const gp::LinearizedSystem6& input) const {
    const float q = fmaxf(input.error, 0.0f);
    const float normalized = q / scale_sq;
    const float weight = 1.0f / (1.0f + normalized);

    // Copying input preserves num_inliers.
    gp::LinearizedSystem6 output = input;
    output.error = scale_sq * log1pf(normalized);
    output.H_target *= weight;
    output.H_source *= weight;
    output.H_target_source *= weight;
    output.b_target *= weight;
    output.b_source *= weight;
    return output;
  }
};

struct CauchyError {
  float scale_sq;

  __device__ float operator()(
    const thrust::pair<int, int>&,
    float error) const {
    const float q = fmaxf(error, 0.0f);
    return scale_sq * log1pf(q / scale_sq);
  }
};

class CauchyDerivatives final : public gp::IntegratedVGICPDerivatives {
public:
  CauchyDerivatives(
    const gp::GaussianVoxelMapGPU::ConstPtr& target,
    const gp::PointCloud::ConstPtr& source,
    float scale)
  : gp::IntegratedVGICPDerivatives(target, source, nullptr, nullptr),
    scale_sq_(scale * scale) {}

  void issue_linearize(
    const Eigen::Isometry3f* d_x,
    gp::LinearizedSystem6* d_output) override {
    issue_linearize_transform_reduce(
      d_x,
      d_output,
      CauchyLinearization{scale_sq_},
      gp::LinearizedSystem6::zero());
  }

  void issue_compute_error(
    const Eigen::Isometry3f* d_xl,
    const Eigen::Isometry3f* d_xe,
    float* d_output) override {
    issue_compute_error_transform_reduce(
      d_xl,
      d_xe,
      d_output,
      CauchyError{scale_sq_},
      0.0f);
  }

private:
  float scale_sq_;
};

class CauchyVGICPFactor final : public gp::IntegratedVGICPFactorGPU {
public:
  CauchyVGICPFactor(
    const gtsam::Pose3& fixed_target_pose,
    gtsam::Key source_key,
    const gp::GaussianVoxelMapGPU::ConstPtr& target,
    const gp::PointCloud::ConstPtr& source,
    float scale)
  : gp::IntegratedVGICPFactorGPU(
      fixed_target_pose, source_key, target, source),
    fixed_target_pose_(fixed_target_pose),
    source_(source),
    scale_(scale) {
    replace_derivatives(
      std::make_unique<CauchyDerivatives>(target, source, scale));
  }

  gtsam::NonlinearFactor::shared_ptr clone() const override {
    // Custom factors must reinstall their custom derivatives when cloned.
    return gtsam::make_shared<CauchyVGICPFactor>(
      fixed_target_pose_,
      keys()[0],
      get_target(),
      source_,
      scale_);
  }

private:
  gtsam::Pose3 fixed_target_pose_;
  gp::PointCloud::ConstPtr source_;
  float scale_;
};
```

The factor can then be used like a normal GPU VGICP factor:

```cpp
auto factor = gtsam::make_shared<CauchyVGICPFactor>(
  fixed_target_pose,
  source_key,
  target_gpu,
  source_gpu,
  1.0f);

graph.add(factor);
```

Transforms used with the standard factor output should preserve `LinearizedSystem6::num_inliers`, since it is used to update the factor's inlier statistics.

For more advanced use cases, the transform-reduce helpers also support custom result types and custom associative reduction operators, allowing additional statistics or diagnostics to be accumulated in the same reduction pass.

### Compatibility

This PR changes the ABI of `gtsam_points_cuda` because `IntegratedVGICPDerivatives` becomes polymorphic. The CUDA library `SOVERSION` is therefore bumped accordingly.

At the behavioral level, the standard `IntegratedVGICPFactorGPU` produces the same VGICP results as before because its implementation uses identity transforms.

Derived factors that call `replace_derivatives()` must override `clone()` and reinstall an equivalent derivative implementation. The inherited `clone()` throws instead of silently creating a factor with the default derivatives.

### Testing

- `VGICPDerivativesTransformReduceTest`: 5/5 passed
- CUDA compute-sanitizer: 0 errors